### PR TITLE
fix: withHover's active to match reactcss

### DIFF
--- a/src/hocs/withHover.tsx
+++ b/src/hocs/withHover.tsx
@@ -7,14 +7,10 @@ const withHover = (Component: React.ComponentType<any>) => (ownerProps: any) => 
 
   const handleMouseOver = () => setHover(true);
   const handleMouseLeave = () => setHover(false);
-  const handleFocus = () => {
-    setFocus(true);
-    setActive(true);
-  };
-  const handleBlur = () => {
-    setFocus(false);
-    setActive(false);
-  };
+  const handleFocus = () => setFocus(true);
+  const handleBlur = () => setFocus(false);
+  const handleMouseDown = () => setActive(true);
+  const handleMouseUp = () => setActive(false);
 
   const hocus = focus || hover;
 
@@ -29,10 +25,18 @@ const withHover = (Component: React.ComponentType<any>) => (ownerProps: any) => 
   return (
     // eslint-disable-next-line jsx-a11y/no-static-element-interactions
     <span
+      // eslint-disable-next-line react/jsx-no-bind
       onMouseOver={handleMouseOver}
+      // eslint-disable-next-line react/jsx-no-bind
       onMouseLeave={handleMouseLeave}
+      // eslint-disable-next-line react/jsx-no-bind
       onFocus={handleFocus}
+      // eslint-disable-next-line react/jsx-no-bind
       onBlur={handleBlur}
+      // eslint-disable-next-line react/jsx-no-bind
+      onMouseDown={handleMouseDown}
+      // eslint-disable-next-line react/jsx-no-bind
+      onMouseUp={handleMouseUp}
     >
       <Component {...props}/>
     </span>


### PR DESCRIPTION
active prop is set on onMouseDown and unset on onMouseUp

ES lint is suddenly getting super grumpy about arrow functions, not sure why as it wasn't before. It won't let me turn off this in a block either so I've done it per line urgh.