### PR TITLE
feat: rename withHover to withInteraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,14 +88,15 @@ const { styles } = useStyles({
 ### caveats
 - due to memoization techniques, any props used by your stylesheet should be passed in as modifiers, otherwise it will not know to recompute the styles when they change
 
-## withHover
+## withInteraction 
+(alias withHover)
 ```ts
 (WrappedComponent) => Component
 ```
 
 ### usage
 ```tsx
-const Interactive = withHover((props) => {
+const Interactive = withInteraction((props) => {
   return (
     <span>
       {props.hover ? 'Hovering' : ''}

--- a/src/hocs/index.ts
+++ b/src/hocs/index.ts
@@ -1,1 +1,4 @@
-export { default as withHover } from './withHover';
+export {
+  default as withHover,
+  default as withInteraction,
+} from './withInteraction';

--- a/src/hocs/withInteraction.tsx
+++ b/src/hocs/withInteraction.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 
-const withHover = (Component: React.ComponentType<any>) => (ownerProps: any) => {
+const withInteraction = (Component: React.ComponentType<any>) => (ownerProps: any) => {
   const [ hover, setHover ] = useState(false);
   const [ focus, setFocus ] = useState(false);
   const [ active, setActive ] = useState(false);
@@ -43,4 +43,4 @@ const withHover = (Component: React.ComponentType<any>) => (ownerProps: any) => 
   );
 };
 
-export default withHover;
+export default withInteraction;


### PR DESCRIPTION
withHover is still provided as an alias to avoid a breaking change