### PR TITLE
feat: dont prefix css grid

### DIFF
--- a/src/hooks/useStyles/autoPrefix.ts
+++ b/src/hooks/useStyles/autoPrefix.ts
@@ -6,6 +6,15 @@ const autoPrefix = (namepsacedStyles: StylesNamespace) => {
   return mapObj((styles) => {
     const initial = {} as StylesVar;
     return reduceObj((acc, _value, _key) => {
+      // opt out of grid prefixing, causes too many IE11 issues
+      // modern browsers support the standard syntax
+      if (_key === 'display' && _value === 'grid') {
+        return {
+          ...acc,
+          [_key]: _value,
+        };
+      }
+
       const key = supportedProperty(_key);
       const value = supportedValue(key, _value);
       return {


### PR DESCRIPTION
Modern evergreen browsers support the standard syntax for grid, and applying `-ms-grid` causes
massive issues in IE11 as it cannot handle many grid layout rules. Autoprefixer disables grid
prefixing by default so this is a pretty acceptable position to take.